### PR TITLE
Refactor rules to use dictionaries and make more modular

### DIFF
--- a/gmail_rules/rules/copy_to.py
+++ b/gmail_rules/rules/copy_to.py
@@ -18,9 +18,8 @@ class Copy_To(_Rule):
     list_of_emails : `list`
         This is a list of email addresses that the mail rule should be
         applied to.
-    rule_flags : `dict`, optional
-        This is a dictionary containing boolean mail rule attributes that
-        either will or will not be applied to the rule
+    rule_defaults : `dict`, optional
+        This is a dictionary containing default rule attributes
 
     Returns
     ----------
@@ -28,7 +27,7 @@ class Copy_To(_Rule):
             Doesn't return anything.
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = None, flags: dict = {}) -> None:
+    def __init__(self, rule_label: str, list_of_emails: list = None, rule_defaults: dict = {}) -> None:
         """Initialize a Copy_To rule object which is a subclass of a 
 
         Parameters
@@ -39,9 +38,8 @@ class Copy_To(_Rule):
         list_of_emails : `list`
             This is a list of email addresses that the mail rule should be
             applied to.
-        rule_flags : `dict`
-            This is a dictionary containing boolean mail rule attributes that
-            either will or will not be applied to the rule
+        rule_defaults : `dict`, optional
+            This is a dictionary containing default rule attributes
 
         Returns
         ----------
@@ -49,11 +47,10 @@ class Copy_To(_Rule):
                 Doesn't return anything.
         """
         rule_name = f"COPY TO: {rule_label}"
-
-        super().__init__(list_of_emails, flags, rule_name)
-
-        self.flags.update(shouldNeverSpam = "true")
+        rule_defaults.update(shouldNeverSpam = "true")
         ## Add rule-type specific flags to the flags dictionary
+
+        super().__init__(list_of_emails, rule_defaults, rule_name)
 
         self.rule_label: str = rule_label
         """This is the label that will be applied to all of the emails with this rule"""

--- a/gmail_rules/rules/move_to.py
+++ b/gmail_rules/rules/move_to.py
@@ -18,9 +18,8 @@ class Move_To(_Rule):
     list_of_emails : `list`
         This is a list of email addresses that the mail rule should be
         applied to.
-    rule_flags : `dict`, optional
-        This is a dictionary containing boolean mail rule attributes that
-        either will or will not be applied to the rule
+    rule_defaults : `dict`, optional
+        This is a dictionary containing default rule attributes
 
     Returns
     ----------
@@ -28,8 +27,8 @@ class Move_To(_Rule):
             Doesn't return anything.
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = None, flags: dict = {}) -> None:
-        """Initialize a Move_To rule object which is a subclass of a 
+    def __init__(self, rule_label: str, list_of_emails: list = None, rule_defaults: dict = {}) -> None:
+        """Initialize a Move_To rule object which is a subclass of :obj:`Rule`
 
         Parameters
         ----------
@@ -39,9 +38,8 @@ class Move_To(_Rule):
         list_of_emails : `list`
             This is a list of email addresses that the mail rule should be
             applied to.
-        rule_flags : `dict`
-            This is a dictionary containing boolean mail rule attributes that
-            either will or will not be applied to the rule
+        rule_defaults : `dict`, optional
+            This is a dictionary containing default rule attributes
 
         Returns
         ----------
@@ -49,11 +47,10 @@ class Move_To(_Rule):
                 Doesn't return anything.
         """
         rule_name = f"MOVE TO: {rule_label}"
-
-        super().__init__(list_of_emails, flags, rule_name)
-
-        self.flags.update(shouldNeverSpam = "true", shouldArchive = "true")
+        rule_defaults.update(shouldNeverSpam = "true", shouldArchive = "true")
         ## Add rule-type specific flags to the flags dictionary
+
+        super().__init__(list_of_emails, rule_defaults, rule_name)
 
         self.rule_label: str = rule_label
         """This is the label that will be applied to all of the emails with this rule"""

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -23,8 +23,6 @@ class Rule:
         List of email addresses that the mail rule applies to
     concatenated_emails : `str`
         String of email addresses that are concatenated together
-    from_attribute : `str`
-        A specific string designated to hold the 'from' mail rule attribute
     rule_header : `str`
         Generic string that precedes the unique section of mail rules
     rule_footer : `str`
@@ -33,23 +31,30 @@ class Rule:
 
     """
 
-    def __init__(self, list_of_emails: list = None, rule_flags: dict = {}, rule_name: str = "Mail Filter") -> None:
+    def __init__(self, list_of_emails: list = None, rule_defaults: dict = {}, rule_name: str = "Mail Filter") -> None:
         """Initialize a new Rule object
 
         Parameters
         ----------
         list_of_emails : `list`, optional
             list of email address to apply rule to, by default `None`
-        rule_flags : `dict`, optional
-            boolean rule flags to add to rule, by default `{}`
+        rule_defaults : `dict`, optional
+            dictionary containing default rule attributes, by default `{}`
         rule_name : `str`, optional
             name of the mail rule, by default `"Mail Filter"`
         """
         self.name: str = rule_name
         """This `str` is the title of the rule"""
 
-        self.final_rule: str = ""
-        """This is the final `str` that can be copied and pasted into an xml to define the rule"""
+        self.attribute_order: tuple[str] = ("label", "from", "subject", "hasTheWord", "doesNotHaveTheWord", "shouldNeverSpam", "shouldArchive", "sizeOperator", "sizeUnit")
+        """Hard-coded order that the rule attributes should appear in"""
+        # self._possible_attributes: frozenset[str] = frozenset(self.attribute_order)
+
+        self.rule_attributes: dict[str, str] = {}
+        """This is a `dict` of all of the rule attributes that should be applied"""
+
+        for default_attribute_name, default_attribute_value in rule_defaults.items():
+            self.add_attribute(default_attribute_name, default_attribute_value)
 
         ###### CHECK WHETHER RULE RELIES ON SPECIFIC EMAIL ADDRESSES ######
         self.emails_list: list[str] = []
@@ -58,14 +63,11 @@ class Rule:
         self.concatenated_emails: str = ""
         """A `str` of the concatenated email addresses that this rule applies to"""
 
-        self.from_attribute: str = ""
-        """This `str` is the attribute associated with a rule that uses 'from' (which is many of them)"""
-
         if list_of_emails is not None:
             # THIS IS THE CASE WHEN SPECIFIC EMAILS ARE PARSED INTO THE FUNCTION
             self.emails_list = self.flatten_list(list_of_emails)
             self.concatenated_emails = self.concatenate(self.emails_list)
-            self.from_attribute = self.define_rule_attribute("from", self.concatenated_emails, True)
+            self.add_attribute("from", self.concatenated_emails)
         ###### CHECK WHETHER RULE RELIES ON SPECIFIC EMAIL ADDRESSES ######
 
         self.rule_header: str = f"{_hp.add_xml_comment(self.name)}\n<entry>\n\t<category term='filter'></category>\n\t<title>{self.name}</title>\n\t<content></content>"
@@ -74,33 +76,58 @@ class Rule:
         self.rule_footer: str = "\n</entry>"
         """This is a `str` representing how each mail rule will end"""
 
-        self.rule_attributes: list[str] = []
-        """This is a `list` of all of the rule attribute strings that should be applied"""
-
-        self.rule_specific_attributes: str = ""
-        """This is a `str` representing attributes that are always applied to a specific type of rule"""
-
-        self.flags: dict[str, str] = rule_flags
-        """This is a `dict` representing all of the flags that are going to be applied to this rule"""
-
     @property
-    def flags_str(self) -> str:
-        """Converts `dict` of rule flags into `str` of standard attributes
+    def _possible_attributes(self) -> frozenset[str]:
+        """`frozenset` of the valid attributes defined in `self.attribute_order`
 
         Returns
         -------
-        flags_string : `str`
+        frozenset[str]
+            `frozenset` of all of the elements in `self.attribute_order`
         """
-        flags_string = ""
-        for attribute_name, attribute_value in self.flags.items():
-            flags_string += f"{self.define_rule_attribute(attribute_name, attribute_value, True)}"
-        return flags_string
+        return frozenset(self.attribute_order)
 
-    def flatten_list(self, list_to_flatten: list) -> list:
+    @property
+    def rule_attributes_xmls(self) -> str:
+        """Converts `dict` of rule attributes into 
+
+        Returns
+        -------
+        rule_attribute_xmls : `dict`
+        """
+        rule_attributes_xmls = {}
+        for attribute_name, attribute_value in self.rule_attributes.items():
+            rule_attributes_xmls[attribute_name] = f"{self.define_rule_attribute(attribute_name, attribute_value)}"
+
+        return rule_attributes_xmls
+    
+    @property
+    def rule_attributes_xml_str(self) -> str:
+        """Converts `dict` of rule attributes into ordered `str` for use in final xml
+
+        Returns
+        -------
+        rule_attribute_xmls_str : `str`
+        """
+        rule_attributes_xmls_str = ""
+        current_rule_xmls = self.rule_attributes_xmls
+
+        for attribute_name in self.attribute_order:
+            if attribute_name in current_rule_xmls:
+                rule_attributes_xmls_str += current_rule_xmls[attribute_name]
+
+        return rule_attributes_xmls_str
+    
+    @property
+    def final_rule_str(self) -> str:
+        """This is the final `str` that can be copied and pasted into an xml to define the rule"""
+        return self.build_rule()
+
+    def flatten_list(self, list_to_flatten: list | list[list]) -> list:
         """
         This function takes a `list` (of potentially nested lists) and recursively
         flattens the list so that it is just a single list of elements that are not
-        of type list
+        of type `list`
         """
         if list_to_flatten == []:
             return list_to_flatten
@@ -110,51 +137,40 @@ class Rule:
 
         return list_to_flatten[:1] + self.flatten_list(list_to_flatten[1:])
 
-    def concatenate(self, elements_input: list = None, separator: str = " OR ") -> str:
+    def concatenate(self, elements_input: list, separator: str = " OR ") -> str:
         """
         Given a list of elements `elements`, this returns the concatenation of the elements with a
-        separator `separator` between them (`" OR "` by default).  Defaults to concaenating
-        `self.emails_list` but can also take in a list of elements.
+        separator `separator` between them (`" OR "` by default)
 
         Parameters
         ----------
-        elements_input : `list`, default = `None`, optional
+        elements_input : `list`
             This is a list of items that should be concatenated together.
         separator : `str`, default = `" OR "`, optional
-            This is the string that will be used to separate individual
-            elements.
+            This is the string that will be used to separate individual elements.
 
         Returns
         -------
         final_output : `str`
             Returns a singular string containing all of the items in `elements` after being
-            concatenated and separated with the `separator`.  Also assigns a new value to
-            `self.concatenated_emails` depending on whether email addresses were being
-            concatenated.
+            concatenated and separated with the `separator`
         """
         final_string = ""
 
-        if elements_input is None:
-            elements = self.emails_list
-
-            if elements == []:
-                return ""
+        if elements_input == []:
+            return ""
 
         else:
             elements = self.flatten_list(elements_input)
 
-        for element in elements:
-            final_string += f"{element}{separator}"
+            for element in elements:
+                final_string += f"{element}{separator}"
 
-        final_output = final_string[:-len(separator)]
+            final_output = final_string[:-len(separator)]
 
-        if elements_input is None:
-            self.concatenated_emails = final_output
-            self.from_attribute = self.define_rule_attribute("from", final_output, True)
+            return final_output
 
-        return final_output
-
-    def define_rule_attribute(self, name: str, value: str, exclude_from_attributes: bool = False) -> str:
+    def define_rule_attribute(self, name: str, value: str) -> str:
         """
         Given an attribute name, its value, and an optional boolean determining whether this
         new attriute should be added to the list of attributes, this function properly builds
@@ -166,24 +182,43 @@ class Rule:
             This is the name of the attribute to define (defined by Google's docs)
         value : `str`
             This is the value of the desired attribute
-        exclude_from_attributes : `bool`, default = `False`, optional
-            This boolean parameter determines whether or not the newly defined attribute
-            should be appended to the `self.rule_attributes` list or whether the newly
-            defined attribute should be returned as `str`
 
         Returns
         ----------
-        rule_line : `str`, optional
-            Returns the properly formatted attribute if and only if `exclude_from_attributes`
-            is `True` (which it is not by default).  Otherwise simply appends `rule_line` to
-            the `self.rule_attributes` list
+        rule_line : `str`
+            Returns the properly formatted attribute
         """
         rule_line = f"\n\t<apps:property name='{name}' value='{value}'/>"
 
-        if not exclude_from_attributes:
-            self.rule_attributes.append(rule_line)
-
         return rule_line
+    
+    def add_attribute(self, name: str, value: str, is_custom_attribute: bool = False) -> None:
+        """Add an attribute to the mail rule
+
+        Parameters
+        ----------
+        name : str
+            Name of the attribute to add
+        value : str
+            Value of the attribute
+        is_custom_attribute : bool, optional
+            Defines whether the attribute being added is custom (use with caution), default = `False`
+        """
+        if name in self.rule_attributes:
+            ## Raise Error when rule already contains a value for this attribute
+            raise KeyError(f"{name} is already an attribute of {self.name}.  Consider calling self.update_attribute() to update the value of this attribute")
+
+        if is_custom_attribute:
+            ## Check whether we are using a custom attribute
+            if name not in self._possible_attributes:
+                ## Add custom attribute name to the possible rule attributes
+                self.attribute_order = self.attribute_order + (name,)
+
+        if name not in self._possible_attributes:
+            ## Raise Error if this attribute name is unallowed
+            raise KeyError(f"{name} is not a valid filter attribute")
+
+        self.rule_attributes[name] = value
 
     def build_rule(self) -> str:
         """
@@ -192,17 +227,8 @@ class Rule:
         `rule_name` which is a `str` representing the name of the mail rule,
         but when the rule is parsed into Gmail, this gets ignored.
         """
-        self.concatenate()
         final_rule = self.rule_header
-
-        final_rule += self.from_attribute
-
-        for rule_attribute in self.rule_attributes:
-            final_rule += f"{rule_attribute}"
-
-        final_rule += f"{self.rule_specific_attributes}{self.flags_str}{self.rule_footer}"
+        final_rule += f"{self.rule_attributes_xml_str}{self.rule_footer}"
         final_rule = final_rule.expandtabs(_hp.TAB_SPACING)
-
-        self.final_rule = final_rule
 
         return final_rule

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,15 @@
+
+import sys
+sys.path.append("../gmail-rules")
+
+import gmail_rules.rules as rules
+import gmail_rules.utils.helpers as hp
+
+new_rule = rules.Copy_To("mango", ["test1", "test2"])
+new_rule.add_attribute("hasTheWord", "Bla bla")
+# new_rule.add_attribute("shouldNeverSpam", "false")
+new_rule.add_attribute("doesNotHaveTheWord", "Three")
+new_rule.add_attribute("doesNotHaveTheWordMANGO", "Three", True)
+new_rule.add_attribute("subject", "Meow")
+print(new_rule.final_rule_str)
+# new_rule.


### PR DESCRIPTION
This changes how rule attributes are stored in a `Rule` object to make things more modular.  Also uses a lot of `@property` decorators.  Consider changing these decorators if they're inefficient.